### PR TITLE
Fix URL duplication bug with sabre/dav CalDAV servers

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ import tseslint from "typescript-eslint";
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   {files: ["**/*.{js,mjs,cjs,ts}"]},
+  {ignores: ["dist/**", "node_modules/**"]},
   {languageOptions: { globals: globals.node }},
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",
+    "@types/axios-mock-adapter": "^1.9.0",
     "@types/base-64": "^1.0.2",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.2",
+    "axios-mock-adapter": "^2.1.0",
     "eslint": "^9.16.0",
     "globals": "^15.13.0",
     "jest": "^29.7.0",

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -42,7 +42,8 @@ function parseRecurrence(recur: ICAL.Recur): RecurrenceRule {
 }
 
 export const parseCalendars = async (
-  responseData: string
+  responseData: string,
+  baseUrl?: string
 ): Promise<Calendar[]> => {
   const calendars: Calendar[] = [];
 
@@ -94,7 +95,7 @@ export const parseCalendars = async (
 
     const calendar: Calendar = {
       displayName: prop["displayname"] ?? "",
-      url: res["href"],
+      url: baseUrl ? new URL(res["href"], baseUrl).toString() : res["href"],
       ctag: prop["getctag"],
       supportedComponents,
     };
@@ -104,7 +105,7 @@ export const parseCalendars = async (
   return calendars;
 };
 
-export const parseEvents = async (responseData: string): Promise<Event[]> => {
+export const parseEvents = async (responseData: string, baseUrl?: string): Promise<Event[]> => {
   const events: Event[] = [];
 
   const parser = new XMLParser({ removeNSPrefix: true });
@@ -163,7 +164,7 @@ export const parseEvents = async (responseData: string): Promise<Event[]> => {
         description: icalEvent.description || undefined,
         location: icalEvent.location || undefined,
         etag: eventData["getetag"] || "",
-        href: obj["href"],
+        href: baseUrl ? new URL(obj["href"], baseUrl).toString() : obj["href"],
         wholeDay: isWholeDay,
         recurrenceRule,
         startTzid,

--- a/tests/url-duplication-fix.test.ts
+++ b/tests/url-duplication-fix.test.ts
@@ -1,0 +1,121 @@
+import { CalDAVClient } from "../src/client";
+
+jest.mock("axios");
+const mockedAxios = jest.mocked(require("axios"));
+
+describe("URL Duplication Bug Fix", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const mockAxiosInstance = {
+      request: jest.fn(),
+      interceptors: {
+        request: { use: jest.fn() },
+      },
+    };
+
+    mockedAxios.create.mockReturnValue(mockAxiosInstance);
+
+    mockAxiosInstance.request
+      .mockResolvedValueOnce({
+        data: `<?xml version="1.0"?>
+          <d:multistatus xmlns:d="DAV:">
+            <d:response>
+              <d:propstat>
+                <d:prop>
+                  <d:current-user-principal>
+                    <d:href>/dav/principals/user@example.com/</d:href>
+                  </d:current-user-principal>
+                </d:prop>
+              </d:propstat>
+            </d:response>
+          </d:multistatus>`,
+      })
+      .mockResolvedValueOnce({
+        data: `<?xml version="1.0"?>
+          <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+            <d:response>
+              <d:propstat>
+                <d:prop>
+                  <c:calendar-home-set>
+                    <d:href>/dav/calendars/user@example.com/</d:href>
+                  </c:calendar-home-set>
+                </d:prop>
+              </d:propstat>
+            </d:response>
+          </d:multistatus>`,
+      });
+
+    return mockAxiosInstance;
+  });
+
+  test("Should not make requests with duplicate /dav/ paths", async () => {
+    const baseUrl = "https://caldav.example.com/dav/";
+
+    const mockAxiosInstance = mockedAxios.create();
+
+    await CalDAVClient.create({
+      baseUrl,
+      auth: { type: "basic", username: "user", password: "pass" },
+    });
+
+    expect(mockedAxios.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: baseUrl,
+      }),
+    );
+
+    const requestCalls = mockAxiosInstance.request.mock.calls;
+
+    expect(requestCalls).toHaveLength(2);
+    expect(requestCalls[0][0].url).toBe("/");
+    expect(requestCalls[1][0].url).toBe("/principals/user@example.com/");
+    expect(requestCalls[1][0].url).not.toContain("/dav/dav/");
+    expect(requestCalls[1][0].url).not.toContain("/dav/principals/");
+  });
+
+  test("Should handle server responses that don't match base path", async () => {
+    const baseUrl = "https://caldav.example.com/";
+
+    const mockAxiosInstance = mockedAxios.create();
+
+    mockAxiosInstance.request
+      .mockResolvedValueOnce({
+        data: `<?xml version="1.0"?>
+          <d:multistatus xmlns:d="DAV:">
+            <d:response>
+              <d:propstat>
+                <d:prop>
+                  <d:current-user-principal>
+                    <d:href>/dav/principals/user@example.com/</d:href>
+                  </d:current-user-principal>
+                </d:prop>
+              </d:propstat>
+            </d:response>
+          </d:multistatus>`,
+      })
+      .mockResolvedValueOnce({
+        data: `<?xml version="1.0"?>
+          <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+            <d:response>
+              <d:propstat>
+                <d:prop>
+                  <c:calendar-home-set>
+                    <d:href>/dav/calendars/user@example.com/</d:href>
+                  </c:calendar-home-set>
+                </d:prop>
+              </d:propstat>
+            </d:response>
+          </d:multistatus>`,
+      });
+
+    await CalDAVClient.create({
+      baseUrl,
+      auth: { type: "basic", username: "user", password: "pass" },
+    });
+
+    const requestCalls = mockAxiosInstance.request.mock.calls;
+
+    expect(requestCalls[1][0].url).toBe("/dav/principals/user@example.com/");
+  });
+});


### PR DESCRIPTION
When base URL ends with /dav/ and server returns absolute paths
starting with /dav/, URLs were incorrectly constructed as
/dav/dav/path instead of /dav/path.

Changes:
- Replace axios baseURL concatenation with proper URL resolution
- Add resolveUrl helper method using URL constructor
- Update parsers to resolve URLs with base URL
- Add null check for baseUrl in create method
- Add focused tests for URL duplication fix
