### PR TITLE
feat(getComponents): opt-in server-side expansion of recurring events…

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -151,11 +151,17 @@ export class CalDAVClient {
    * Fetches all events from a specific calendar.
    * @param calendarUrl - The URL of the calendar to fetch events from.
    * @param options - Optional parameters for fetching events.
+   * @param options.expand - When `true` and a time range is set, instructs the
+   *   server to expand recurring events into individual occurrences (RFC 4791
+   *   §9.6.5). The returned events will not contain `recurrenceRule`; each
+   *   instance has its own `start`/`end`. Without this flag, recurring events
+   *   are returned as their master VEVENT with `recurrenceRule` and the caller
+   *   is responsible for expanding occurrences.
    * @returns An array of Event objects.
    */
   public async getEvents(
     calendarUrl: string,
-    options?: { start?: Date; end?: Date; all?: boolean },
+    options?: { start?: Date; end?: Date; all?: boolean; expand?: boolean },
   ): Promise<Event[]> {
     return getProtocolComponents<Event>(
       calendarUrl,
@@ -228,12 +234,14 @@ export class CalDAVClient {
   /**
    * Fetches all todos from a specific calendar.
    * @param calendarUrl - The URL of the calendar to fetch todos from.
-   * @param options - Optional parameters for fetching todos.
+   * @param options - Optional parameters for fetching todos. `expand` is
+   *   ignored unless `all` is overridden to `false`, since the default for
+   *   todos is to return all components irrespective of time bounds.
    * @returns An array of Todo objects.
    */
   public async getTodos(
     calendarUrl: string,
-    options?: { start?: Date; end?: Date; all?: boolean },
+    options?: { start?: Date; end?: Date; all?: boolean; expand?: boolean },
   ): Promise<Todo[]> {
     return getProtocolComponents<Todo>(
       calendarUrl,

--- a/src/protocol/components.ts
+++ b/src/protocol/components.ts
@@ -27,11 +27,11 @@ export const getComponents = async <T>(
   component: ComponentType,
   parseFn: (xml: string) => Promise<T[]>,
   report: ReportFn,
-  options?: { start?: Date; end?: Date; all?: boolean },
+  options?: { start?: Date; end?: Date; all?: boolean; expand?: boolean },
 ): Promise<T[]> => {
   const now = new Date();
   const defaultEnd = new Date(now.getTime() + 3 * 7 * 24 * 60 * 60 * 1000);
-  const { start = now, end = defaultEnd, all } = options || {};
+  const { start = now, end = defaultEnd, all, expand } = options || {};
 
   const timeRangeFilter =
     start && end && !all
@@ -40,11 +40,22 @@ export const getComponents = async <T>(
          </c:comp-filter>`
       : `<c:comp-filter name="${component}"/>`;
 
+  // RFC 4791 §9.6.5: <C:expand> is only valid inside a time-bounded query.
+  // When enabled, the server returns the individual occurrences of a
+  // recurring component (without RRULE/RDATE/EXRULE/EXDATE) instead of the
+  // master VEVENT/VTODO with its recurrence rule.
+  const calendarData =
+    expand && start && end && !all
+      ? `<c:calendar-data>
+           <c:expand start="${formatDate(start)}" end="${formatDate(end)}"/>
+         </c:calendar-data>`
+      : `<c:calendar-data/>`;
+
   const requestBody = `
     <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
       <d:prop>
         <d:getetag/>
-        <c:calendar-data/>
+        ${calendarData}
       </d:prop>
       <c:filter>
         <c:comp-filter name="VCALENDAR">

--- a/tests/unit/components.test.ts
+++ b/tests/unit/components.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test, vi } from "vitest";
+import { getComponents } from "../../src/protocol/components";
+
+const EMPTY_MULTISTATUS = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"></d:multistatus>`;
+
+describe("getComponents request body", () => {
+  test("omits <C:expand> by default — recurring events are returned as their master VEVENT", async () => {
+    const report = vi.fn(async () => EMPTY_MULTISTATUS);
+    const parse = vi.fn(async () => []);
+
+    await getComponents(
+      "https://example.test/cal/",
+      "VEVENT",
+      parse,
+      report,
+      {
+        start: new Date("2026-06-10T00:00:00Z"),
+        end: new Date("2026-06-24T23:59:59Z"),
+      },
+    );
+
+    expect(report).toHaveBeenCalledTimes(1);
+    const body = report.mock.calls[0][1];
+    expect(body).toContain("<c:calendar-data/>");
+    expect(body).not.toContain("c:expand");
+  });
+
+  test("includes <C:expand> when expand:true is set together with a time range", async () => {
+    const report = vi.fn(async () => EMPTY_MULTISTATUS);
+    const parse = vi.fn(async () => []);
+
+    const start = new Date("2026-06-10T00:00:00Z");
+    const end = new Date("2026-06-24T23:59:59Z");
+
+    await getComponents(
+      "https://example.test/cal/",
+      "VEVENT",
+      parse,
+      report,
+      { start, end, expand: true },
+    );
+
+    const body = report.mock.calls[0][1];
+    expect(body).not.toContain("<c:calendar-data/>");
+    expect(body).toMatch(
+      /<c:calendar-data>\s*<c:expand\s+start="20260610T000000Z"\s+end="20260624T235959Z"\/>\s*<\/c:calendar-data>/,
+    );
+  });
+
+  test("ignores expand:true when no time range is in effect (all:true)", async () => {
+    const report = vi.fn(async () => EMPTY_MULTISTATUS);
+    const parse = vi.fn(async () => []);
+
+    await getComponents(
+      "https://example.test/cal/",
+      "VEVENT",
+      parse,
+      report,
+      {
+        start: new Date("2026-06-10T00:00:00Z"),
+        end: new Date("2026-06-24T23:59:59Z"),
+        all: true,
+        expand: true,
+      },
+    );
+
+    const body = report.mock.calls[0][1];
+    expect(body).toContain("<c:calendar-data/>");
+    expect(body).not.toContain("c:expand");
+  });
+});


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                             
                  
  `getEvents`/`getTodos` send a `<C:calendar-data/>` request body without                                                                                                                                                                
  `<C:expand>`. The server therefore returns the *master* VEVENT/VTODO of a
  recurring series (with its `RRULE`) and not the individual occurrences in the                                                                                                                                                          
  queried time range.                                                                                                                                                                                                                    
   
  Practical effect on Nextcloud/Sabre.io: a weekly meeting that started six                                                                                                                                                              
  months ago is only ever returned once — at its original `DTSTART`. A caller
  asking "what's on my calendar between X and Y" misses every per-instance                                                                                                                                                               
  occurrence whose `DTSTART` is outside `[X, Y]`. Modifying a single instance                                                                                                                                                            
  via `RECURRENCE-ID` makes the gap visible, since now only the modified                                                                                                                                                                 
  override comes back.                                                                                                                                                                                                                   
                                                                                                                                                                                                                                         
  ## Change                                                                                                                                                                                                                              
   
  Adds an opt-in `expand?: boolean` to `getEvents`/`getTodos`. When set together                                                                                                                                                         
  with `start`/`end` (and not `all`), the REPORT body includes:
                                                                                                                                                                                                                                         
  ```xml
  <c:calendar-data>                                                                                                                                                                                                                      
    <c:expand start="..." end="..."/>
  </c:calendar-data>                                                                                                                                                                                                                     
  ```
                                                                                                                                                                                                                                         
  The server then expands recurring components and returns each occurrence
  without `RRULE`/`RDATE`/`EXRULE`/`EXDATE` (RFC 4791 §9.6.5).
                                                                                                                                                                                                                                         
  Default behavior is unchanged.                                                                                                                                                                                                         
                                                                                                                                                                                                                                         
  Three new unit tests cover the body construction. Verified end-to-end                                                                                                                                                                  
  against Nextcloud: 14-day window on a real calendar went from 6 events
  to 21 — the missing expansions of weekly series.                                                                                                                                                                                       
 